### PR TITLE
fix: update STT record keybind

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,9 +201,12 @@ If a path is not set, the built-in default prompt is used.
 
 ### Speech-to-text
 
+The `leader` key in OpenCode is `ctrl+x`. So `leader+o` means press `ctrl+x`
+then `o`.
+
 | Command       | Keybind    | Description                            |
 | ------------- | ---------- | -------------------------------------- |
-| `/stt-record` | `ctrl+r`   | Start/stop recording + transcribe      |
+| `/stt-record` | `leader+o` | Start/stop recording + transcribe      |
 | `/stt-submit` | `leader+r` | Stop recording, transcribe, and submit |
 | `/stt-stop`   |            | Cancel recording                       |
 | `/stt-model`  |            | Select whisper model                   |
@@ -297,7 +300,7 @@ for an optional global `Fn` key setup.
 
 Behavior:
 
-- Press `Fn` to send `ctrl+r` and start recording.
+- Press `Fn` to send `leader+o` and start recording.
 - Hold `Fn` for at least 0.5 seconds and release to send `leader+r`, which
   stops recording, normalizes, and submits the prompt.
 

--- a/examples/hammerspoon/ghostty-fn.lua
+++ b/examples/hammerspoon/ghostty-fn.lua
@@ -1,7 +1,7 @@
 -- Optional example for OpenCode + opencode-voice in Ghostty.
 --
 -- Workflow:
--- - Press Fn to send ctrl+r and start recording.
+-- - Press Fn to send leader+o and start recording.
 -- - Hold Fn for at least LONG_PRESS_THRESHOLD_SECONDS and release to send
 --   leader+r, which stops recording, normalizes, and submits the prompt.
 --
@@ -19,7 +19,7 @@ local inspect = hs.inspect
 local APP_NAME = "Ghostty"
 local TARGET_TERMINAL = 1
 local LONG_PRESS_THRESHOLD_SECONDS = 0.5
-local START_RECORDING_ACTION = "\\x12"
+local START_RECORDING_ACTION = "\\x18o"
 local SUBMIT_RECORDING_ACTION = "\\x18r"
 
 local fnPressed = false

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@
 // Runtime state (model, mic, voice, tts mode) persisted via api.kv.
 //
 // Commands:
-//   /stt-record (ctrl+r)  - start/stop recording + transcribe
+//   /stt-record (leader+o)- start/stop recording + transcribe
 //   /stt-submit (leader+r)- stop recording + transcribe + submit
 //   /stt-stop             - cancel recording
 //   /stt-model            - select whisper model

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -442,7 +442,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       description: sttApiEndpoint
         ? "Toggle recording; press again to stop and transcribe via API"
         : "Toggle recording; press again to stop and transcribe",
-      keybind: "ctrl+r",
+      keybind: "<leader>o",
       slash: { name: "stt-record" },
       onSelect() {
         if (processing) {


### PR DESCRIPTION
Ctrl+r is bound to Opencode's "Rename Session", you cannot use it for **/stt-record**

Changed keybind to `<leader>o` instead.