### PR TITLE
feat: add trimSilence option to control sox silence trimming

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ For unauthenticated local endpoints (e.g. Ollama):
 - `retries` _(optional)_ - number of retry attempts for transient LLM failures
 - `tmpDir` _(optional)_ - directory used for the temporary STT recording file (default `/tmp`)
 - `sttLanguage` _(optional)_ - spoken language passed to local `whisper-cli -l` (default `auto`; any whisper.cpp language code, e.g. `en`, `zh`). Can be changed at runtime via `/stt-language`
+- `trimSilence` _(optional)_ - whether to remove leading silence from recordings (default `true`). Set to `false` if your recordings are missing the first word or syllable
 
 ### Logging
 

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -232,7 +232,7 @@ function forceKillSox(logger) {
   } catch {}
 }
 
-function startRecording(kv, backend, toast, logger) {
+function startRecording(kv, backend, toast, logger, trimSilence = true) {
   if (soxProc) {
     logger?.log("STT", "Start recording skipped: sox already running", "debug");
     return;
@@ -253,9 +253,10 @@ function startRecording(kv, backend, toast, logger) {
     "debug",
   );
 
+  const silenceArgs = trimSilence ? ["silence", "1", "0.1", "1%"] : [];
   soxProc = spawn(
     "sox",
-    [...inputArgs, "-r", "16000", "-c", "1", "-b", "16", wavFile, "silence", "1", "0.1", "1%"],
+    [...inputArgs, "-r", "16000", "-c", "1", "-b", "16", wavFile, ...silenceArgs],
     {
       stdio: ["ignore", "ignore", "pipe"],
       detached: false,
@@ -665,7 +666,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           toast("Stopping, transcribing...");
           doTranscribePipeline(kv, complete, client, toast, systemPrompt, false, logger);
         } else {
-          startRecording(kv, backend, toast, logger);
+          startRecording(kv, backend, toast, logger, opts?.trimSilence);
           if (recording) toast("Recording... press again to transcribe");
         }
       },


### PR DESCRIPTION
### Problem
sox's `silence 1 0.1 1%` parameter removes leading silence from recordings, but it can sometimes clip the first word or two.

### Solution
Add a `trimSilence` optional parameter (default `true`) that keeps the original behavior. Allow setting it to `false` to omit the silence parameter from the sox command, preserving the full recording from the start.

_This behavior / issue was observed on WSL._