### PR TITLE
feat: enhance audio backend detection for Linux/WLS2 and input devi…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,21 @@ On WSL2, make sure [WSLg](https://learn.microsoft.com/windows/wsl/tutorials/gui-
 is running — it bridges the Windows microphone into WSL as a PulseAudio source
 (typically named `RDPSource`), which you can then pick with `/stt-mic`.
 
+**WSL2 audio troubleshooting.** There is no `/dev/snd` in WSL2 — that is
+normal. Audio goes through WSLg's PulseAudio server at `/mnt/wslg/PulseServer`,
+so ALSA-only tools like `arecord -l` will never list a device. If `/stt-mic`
+finds no devices or `pactl info` fails with `Connection refused`, WSLg's
+PulseAudio is stuck; fix it from Windows PowerShell:
+
+```powershell
+wsl --shutdown   # then reopen Ubuntu (closes all WSL sessions)
+```
+
+If the source list is still empty after a restart, check Windows
+**Settings → Privacy & security → Microphone** and enable both "Microphone
+access" and "Let desktop apps access your microphone" (WSLg captures audio via
+a desktop RDP client), then run `wsl --update` for the latest WSLg.
+
 Verify your microphone by recording a 3-second clip and playing it back.
 Remove the temp file once you've heard yourself clearly; skip building
 whisper.cpp until this works, otherwise `/stt-mic` will have nothing to select:
@@ -123,13 +138,13 @@ sudo ln -sf ~/opt/whisper.cpp/build/bin/whisper-cli /usr/local/bin/whisper-cli
 Check your GPU with `nvidia-smi` and your toolkit with `nvcc --version`, then
 pick the arch code from the table:
 
-| GPU family        | Arch      | `CMAKE_CUDA_ARCHITECTURES` | Min. CUDA |
-|-------------------|-----------|----------------------------|-----------|
-| RTX 20 / T4       | Turing    | `75`                       | 10.0      |
-| RTX 30 / A100     | Ampere    | `86`                       | 11.0      |
-| RTX 40 / L40      | Ada       | `89`                       | 11.8      |
-| H100              | Hopper    | `90`                       | 12.0      |
-| RTX 50 / B100     | Blackwell | `120`                      | 13.0      |
+| GPU family    | Arch      | `CMAKE_CUDA_ARCHITECTURES` | Min. CUDA |
+| ------------- | --------- | -------------------------- | --------- |
+| RTX 20 / T4   | Turing    | `75`                       | 10.0      |
+| RTX 30 / A100 | Ampere    | `86`                       | 11.0      |
+| RTX 40 / L40  | Ada       | `89`                       | 11.8      |
+| H100          | Hopper    | `90`                       | 12.0      |
+| RTX 50 / B100 | Blackwell | `120`                      | 13.0      |
 
 ```bash
 git clone https://github.com/ggml-org/whisper.cpp ~/opt/whisper.cpp
@@ -173,11 +188,11 @@ rm /tmp/smoke.wav
 Check the first `system_info:` line in the output to confirm the expected
 backend is active:
 
-| Install                       | Expect                    |
-|-------------------------------|---------------------------|
-| macOS Homebrew (Apple Silicon)| `METAL = 1`               |
-| Linux CUDA build              | `CUDA : ARCHS = <n>`      |
-| CPU-only                      | `METAL = 0` / no `CUDA`   |
+| Install                        | Expect                  |
+| ------------------------------ | ----------------------- |
+| macOS Homebrew (Apple Silicon) | `METAL = 1`             |
+| Linux CUDA build               | `CUDA : ARCHS = <n>`    |
+| CPU-only                       | `METAL = 0` / no `CUDA` |
 
 Reference `encode time` on a 4-second clip: CPU `medium` ≈ 15–30 s; CUDA
 `medium` ≈ 100–200 ms; CUDA `large-v3-turbo` ≈ 100–300 ms. Apple Silicon

--- a/README.md
+++ b/README.md
@@ -56,17 +56,134 @@ rm -rf ~/.cache/opencode/packages/@renjfk/
 
 ### Speech-to-text
 
+The plugin uses [whisper.cpp](https://github.com/ggml-org/whisper.cpp) via a
+`whisper-cli` binary and `sox` for microphone capture. Follow the subsection
+for your OS to install the binary and verify your microphone, then run the
+shared **Download model & smoke test** step at the end.
+
+#### macOS
+
+Install the `whisper-cpp` bottle (ships a `whisper-cli` with Metal enabled on
+Apple Silicon) and `sox`:
+
 ```bash
 brew install whisper-cpp sox
 ```
 
-Download a whisper model to `~/.local/share/whisper-cpp/`:
+Verify your microphone by recording a 3-second clip and playing it back. The
+first `sox -d` invocation triggers a macOS microphone permission prompt —
+grant it in **System Settings → Privacy & Security → Microphone**, then rerun.
+Remove the temp file once you've heard yourself clearly:
+
+```bash
+sox -d /tmp/mic-check.wav trim 0 3   # speak for 3 seconds
+play /tmp/mic-check.wav              # you should hear yourself
+rm /tmp/mic-check.wav                # delete after verification
+```
+
+#### Linux (including WSL2)
+
+Install `sox` with its PulseAudio driver (a separate package on Debian/Ubuntu),
+the PulseAudio tools so the plugin can enumerate input devices via `pactl`,
+and the build tools for whisper.cpp:
+
+```bash
+sudo apt install sox libsox-fmt-pulse pulseaudio-utils build-essential cmake
+```
+
+On WSL2, make sure [WSLg](https://learn.microsoft.com/windows/wsl/tutorials/gui-apps)
+is running — it bridges the Windows microphone into WSL as a PulseAudio source
+(typically named `RDPSource`), which you can then pick with `/stt-mic`.
+
+Verify your microphone by recording a 3-second clip and playing it back.
+Remove the temp file once you've heard yourself clearly; skip building
+whisper.cpp until this works, otherwise `/stt-mic` will have nothing to select:
+
+```bash
+sox -d /tmp/mic-check.wav trim 0 3   # speak for 3 seconds
+play /tmp/mic-check.wav              # you should hear yourself
+rm /tmp/mic-check.wav                # delete after verification
+```
+
+`whisper-cli` is not packaged for Linux, so build whisper.cpp from source.
+Pick **one** of the two builds below.
+
+**CPU build** — works on any machine, adequate for `tiny`/`base`/`small`
+models:
+
+```bash
+git clone https://github.com/ggml-org/whisper.cpp ~/opt/whisper.cpp
+cmake -B ~/opt/whisper.cpp/build -S ~/opt/whisper.cpp \
+  -DCMAKE_BUILD_TYPE=Release -DWHISPER_BUILD_TESTS=OFF
+cmake --build ~/opt/whisper.cpp/build -j --target whisper-cli
+sudo ln -sf ~/opt/whisper.cpp/build/bin/whisper-cli /usr/local/bin/whisper-cli
+```
+
+**CUDA build** — NVIDIA GPU, ~100× faster encode for `medium`/`large` models.
+Check your GPU with `nvidia-smi` and your toolkit with `nvcc --version`, then
+pick the arch code from the table:
+
+| GPU family        | Arch      | `CMAKE_CUDA_ARCHITECTURES` | Min. CUDA |
+|-------------------|-----------|----------------------------|-----------|
+| RTX 20 / T4       | Turing    | `75`                       | 10.0      |
+| RTX 30 / A100     | Ampere    | `86`                       | 11.0      |
+| RTX 40 / L40      | Ada       | `89`                       | 11.8      |
+| H100              | Hopper    | `90`                       | 12.0      |
+| RTX 50 / B100     | Blackwell | `120`                      | 13.0      |
+
+```bash
+git clone https://github.com/ggml-org/whisper.cpp ~/opt/whisper.cpp
+cmake -B ~/opt/whisper.cpp/build -S ~/opt/whisper.cpp \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DGGML_CUDA=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=89 \
+  -DWHISPER_BUILD_TESTS=OFF
+cmake --build ~/opt/whisper.cpp/build -j --target whisper-cli
+sudo ln -sf ~/opt/whisper.cpp/build/bin/whisper-cli /usr/local/bin/whisper-cli
+```
+
+If you have multiple CUDA toolkits installed (e.g. Blackwell requires CUDA 13
+while the default `nvcc` is 12), also pass `-DCMAKE_CUDA_COMPILER=/usr/local/cuda-13.3/bin/nvcc`
+to point at the matching `nvcc`. CUDA runtime libraries are resolved via
+ldconfig; no `LD_LIBRARY_PATH` is needed.
+
+At runtime the plugin records through sox's `pulseaudio` driver when `pactl`
+is available, and falls back to sox's default device otherwise.
+
+#### Download model & smoke test
+
+Download a whisper model to `~/.local/share/whisper-cpp/` (same path on both
+OSes):
 
 ```bash
 mkdir -p ~/.local/share/whisper-cpp
 curl -L -o ~/.local/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin \
   https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin
 ```
+
+Smoke-test the install by transcribing a short recording:
+
+```bash
+sox -d /tmp/smoke.wav trim 0 4   # say something for 4 seconds
+whisper-cli -m ~/.local/share/whisper-cpp/ggml-large-v3-turbo-q5_0.bin \
+  -f /tmp/smoke.wav -l auto -nt
+rm /tmp/smoke.wav
+```
+
+Check the first `system_info:` line in the output to confirm the expected
+backend is active:
+
+| Install                       | Expect                    |
+|-------------------------------|---------------------------|
+| macOS Homebrew (Apple Silicon)| `METAL = 1`               |
+| Linux CUDA build              | `CUDA : ARCHS = <n>`      |
+| CPU-only                      | `METAL = 0` / no `CUDA`   |
+
+Reference `encode time` on a 4-second clip: CPU `medium` ≈ 15–30 s; CUDA
+`medium` ≈ 100–200 ms; CUDA `large-v3-turbo` ≈ 100–300 ms. Apple Silicon
+Metal timings are hardware-dependent but typically sub-second. If your GPU
+build shows CPU-level timings, the GPU backend failed to load — on Linux,
+re-check `nvidia-smi` and rebuild with the arch code from the table above.
 
 ### Text-to-speech
 
@@ -218,6 +335,10 @@ If a path is not set, the built-in default prompt is used.
 | `/stt-model`  |            | Select whisper model                   |
 | `/stt-mic`    |            | Select microphone                      |
 
+`/stt-mic` lists CoreAudio input devices on macOS, and PulseAudio sources on
+Linux (via `pactl`, monitor sources excluded). On systems without a supported
+device listing, "System default" uses sox's default device (`sox -d`).
+
 ### Text-to-speech
 
 The `leader` key in OpenCode is `ctrl+x`. So `leader+s` means press `ctrl+x`
@@ -234,7 +355,8 @@ then `s`.
 
 ### STT pipeline
 
-1. `sox` records audio from your microphone
+1. `sox` records audio from your microphone (CoreAudio on macOS, PulseAudio on
+   Linux when `pactl` is available, sox default device otherwise)
 2. `whisper-cli` transcribes locally using a ggml model, or an OpenAI-compatible
    API endpoint if `sttEndpoint` is configured
 3. LLM normalizes the transcription: fixes punctuation, removes filler words,

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ For unauthenticated local endpoints (e.g. Ollama):
 - `chatTemplateKwargs` _(optional)_ - extra keyword arguments passed to the model's chat template (e.g. `{"enable_thinking": false}` for Qwen models to disable chain-of-thought)
 - `retries` _(optional)_ - number of retry attempts for transient LLM failures
 - `tmpDir` _(optional)_ - directory used for the temporary STT recording file (default `/tmp`)
+- `sttLanguage` _(optional)_ - spoken language passed to local `whisper-cli -l` (default `auto`; any whisper.cpp language code, e.g. `en`, `zh`). Can be changed at runtime via `/stt-language`
 
 ### Logging
 
@@ -327,17 +328,22 @@ If a path is not set, the built-in default prompt is used.
 
 ### Speech-to-text
 
-| Command       | Keybind    | Description                            |
-| ------------- | ---------- | -------------------------------------- |
-| `/stt-record` | `ctrl+r`   | Start/stop recording + transcribe      |
-| `/stt-submit` | `leader+r` | Stop recording, transcribe, and submit |
-| `/stt-stop`   |            | Cancel recording                       |
-| `/stt-model`  |            | Select whisper model                   |
-| `/stt-mic`    |            | Select microphone                      |
+| Command         | Keybind    | Description                            |
+| --------------- | ---------- | -------------------------------------- |
+| `/stt-record`   | `ctrl+r`   | Start/stop recording + transcribe      |
+| `/stt-submit`   | `leader+r` | Stop recording, transcribe, and submit |
+| `/stt-stop`     |            | Cancel recording                       |
+| `/stt-model`    |            | Select whisper model                   |
+| `/stt-language` |            | Select transcription language          |
+| `/stt-mic`      |            | Select microphone                      |
 
 `/stt-mic` lists CoreAudio input devices on macOS, and PulseAudio sources on
 Linux (via `pactl`, monitor sources excluded). On systems without a supported
 device listing, "System default" uses sox's default device (`sox -d`).
+
+`/stt-language` offers a curated list of common languages (plus auto-detect)
+and only affects local `whisper-cli` transcription, not the STT API. Languages
+outside the list can be set via the `sttLanguage` plugin option.
 
 ### Text-to-speech
 

--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@
 //   /stt-submit (leader+r)- stop recording + transcribe + submit
 //   /stt-stop             - cancel recording
 //   /stt-model            - select whisper model
+//   /stt-language         - select transcription language
 //   /stt-mic              - select microphone
 //   /tts-speak (leader+s)- read last response aloud
 //   /tts-mode (leader+v) - toggle auto TTS on/off

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -112,6 +112,41 @@ function detectAudioBackend() {
   }
 }
 
+// ---- Audio server diagnostics ----
+
+export function isWSL() {
+  return Boolean(process.env.WSL_DISTRO_NAME || process.env.WSL_INTEROP);
+}
+
+// Unlike `pactl --version`, `pactl info` actually connects to the server.
+function pulseServerHealth() {
+  try {
+    execSync("pactl info", { stdio: "ignore", timeout: 3000 });
+    return { ok: true };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// User-facing hint for missing devices / recording failures. On WSL the audio
+// server is WSLg's PulseAudio, which can wedge and needs a `wsl --shutdown`.
+export function buildAudioHint({ backend, serverOk, isWsl }) {
+  if (backend !== "pulseaudio") return "No input devices found";
+  if (serverOk) return "No input devices found - check your audio input source configuration";
+  if (isWsl) {
+    return 'Audio server unreachable. On WSL, WSLg\'s PulseAudio may be stuck - run "wsl --shutdown" on Windows, then reopen Ubuntu';
+  }
+  return "Audio server unreachable - check that PipeWire/PulseAudio is running";
+}
+
+// Appends a server-health hint to recording failure messages when the
+// PulseAudio server is unreachable (e.g. wedged WSLg on WSL).
+function audioFailureSuffix(backend) {
+  if (backend !== "pulseaudio") return "";
+  if (pulseServerHealth().ok) return "";
+  return `. ${buildAudioHint({ backend, serverOk: false, isWsl: isWSL() })}`;
+}
+
 // Input device descriptors: name is the value passed to sox, label is shown in the UI.
 export function parsePactlSources(jsonText) {
   const data = JSON.parse(jsonText);
@@ -236,7 +271,7 @@ function startRecording(kv, backend, toast, logger) {
     logger?.log("STT", `Recording failed: ${err.message}`, "error");
     if (recording) {
       recording = false;
-      toast(`Recording failed: ${err.message}`, "error");
+      toast(`Recording failed: ${err.message}${audioFailureSuffix(backend)}`, "error");
     }
   });
 
@@ -250,7 +285,10 @@ function startRecording(kv, backend, toast, logger) {
     if (recording && code !== 0 && code !== null && !processing) {
       recording = false;
       const errLine = soxStderr.trim().split("\n").pop();
-      toast(`Recording error: ${errLine || `sox exited (code=${code})`}`, "error");
+      toast(
+        `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
+        "error",
+      );
     }
   });
 
@@ -745,7 +783,10 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
         const current = kv.get("stt.mic", "");
         const devices = listInputDevices(backend);
         if (devices.length === 0) {
-          toast("No input devices found");
+          const serverOk = backend !== "pulseaudio" || pulseServerHealth().ok;
+          const hint = buildAudioHint({ backend, serverOk, isWsl: isWSL() });
+          logger?.log("STT", `No input devices: ${hint}`, "warn");
+          toast(hint);
           return;
         }
         api.ui.dialog.replace(() =>

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -36,6 +36,25 @@ const MODELS = {
 };
 const DEFAULT_MODEL = "large-v3-turbo-q5_0";
 
+const DEFAULT_LANGUAGE = "auto";
+// Curated subset for the /stt-language picker; options.sttLanguage accepts any
+// whisper.cpp language code.
+const LANGUAGES = {
+  auto: { label: "Auto-detect" },
+  en: { label: "English" },
+  zh: { label: "Chinese" },
+  yue: { label: "Cantonese" },
+  ja: { label: "Japanese" },
+  ko: { label: "Korean" },
+  de: { label: "German" },
+  fr: { label: "French" },
+  es: { label: "Spanish" },
+  pt: { label: "Portuguese" },
+  ru: { label: "Russian" },
+  it: { label: "Italian" },
+};
+let sttDefaultLanguage = DEFAULT_LANGUAGE;
+
 export function isOpenRouterEndpoint(endpoint) {
   return /(^https?:\/\/)?([^/]+\.)?openrouter\.ai(\/|$)/i.test(endpoint || "");
 }
@@ -263,10 +282,19 @@ function getModelPath(kv) {
   return path.join(getModelsDir(), MODELS[getModelName(kv)].file);
 }
 
+function getLanguage(kv) {
+  return kv.get("stt.language") || sttDefaultLanguage;
+}
+
+export function buildWhisperArgs(modelPath, wavFile, language) {
+  return ["-m", modelPath, "-f", wavFile, "-l", language || DEFAULT_LANGUAGE, "-np", "-nt"];
+}
+
 function transcribe(kv, logger) {
   const wavFile = path.join(tmpDir, WAV_FILENAME);
   const mp = getModelPath(kv);
-  logger?.log("STT", `Local transcription requested model=${mp}`, "debug");
+  const lang = getLanguage(kv);
+  logger?.log("STT", `Local transcription requested model=${mp} language=${lang}`, "debug");
   if (!fs.existsSync(mp)) {
     logger?.log("STT", `Whisper model missing: ${mp}`, "error");
     return Promise.resolve({
@@ -285,7 +313,7 @@ function transcribe(kv, logger) {
   return new Promise((resolve) => {
     let stdout = "";
     let stderr = "";
-    const proc = spawn("whisper-cli", ["-m", mp, "-f", wavFile, "-np", "-nt"], {
+    const proc = spawn("whisper-cli", buildWhisperArgs(mp, wavFile, lang), {
       stdio: ["ignore", "pipe", "pipe"],
     });
     logger?.log("STT", `Started whisper-cli pid=${proc.pid}`, "debug");
@@ -311,6 +339,14 @@ function transcribe(kv, logger) {
 
     proc.on("exit", (code) => {
       clearTimeout(timer);
+      // whisper-cli exits 0 even for an unknown language, printing the error to
+      // stderr instead; surface it rather than reporting "no speech detected".
+      const langError = stderr.match(/error: unknown language '([^']+)'/);
+      if (langError) {
+        logger?.log("STT", `whisper-cli rejected language: ${langError[1]}`, "error");
+        resolve({ error: `Unknown whisper language: ${langError[1]}` });
+        return;
+      }
       if (code !== 0) {
         logger?.log("STT", `whisper-cli exited code=${code} stderr=${stderr.trim()}`, "error");
         resolve({ error: stderr.trim().split("\n").pop() || `whisper-cli exited (code=${code})` });
@@ -560,6 +596,11 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
     );
   }
 
+  if (opts?.sttLanguage) {
+    sttDefaultLanguage = opts.sttLanguage;
+  }
+  logger?.log("STT", `Default language=${sttDefaultLanguage}`, "debug");
+
   tmpDir = opts?.tmpDir || "/tmp";
   try {
     fs.mkdirSync(tmpDir, { recursive: true });
@@ -669,6 +710,30 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
             }),
           );
         }
+      },
+    },
+    {
+      title: "STT: select language",
+      value: "stt.language",
+      description: "Choose transcription language (local whisper-cli only)",
+      slash: { name: "stt-language" },
+      onSelect() {
+        const current = getLanguage(kv);
+        api.ui.dialog.replace(() =>
+          api.ui.DialogSelect({
+            title: "Select transcription language",
+            current,
+            options: Object.entries(LANGUAGES).map(([key, v]) => ({
+              title: v.label,
+              value: key,
+              onSelect() {
+                kv.set("stt.language", key);
+                toast(`Whisper language: ${v.label}`);
+                api.ui.dialog.clear();
+              },
+            })),
+          }),
+        );
       },
     },
     {

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -26,6 +26,7 @@ const MODELS = {
   },
   "large-v3-turbo-q8_0": { label: "Large v3 Turbo Q8", file: "ggml-large-v3-turbo-q8_0.bin" },
   "large-v3-turbo": { label: "Large v3 Turbo (full)", file: "ggml-large-v3-turbo.bin" },
+  "medium-q5_0": { label: "Medium Q5 (multilingual, faster)", file: "ggml-medium-q5_0.bin" },
   "small.en": { label: "Small English", file: "ggml-small.en.bin" },
   small: { label: "Small Multilingual", file: "ggml-small.bin" },
   "base.en": { label: "Base English", file: "ggml-base.en.bin" },
@@ -80,19 +81,81 @@ function getModelsDir() {
   return MODELS_DIRS[0];
 }
 
-function listInputDevices() {
+// ---- Audio backend detection (coreaudio / pulseaudio / sox default) ----
+
+function detectAudioBackend() {
+  if (process.platform === "darwin") return "coreaudio";
   try {
-    const json = execSync("system_profiler SPAudioDataType -json 2>/dev/null", {
-      encoding: "utf-8",
-      timeout: 5000,
-    });
-    const data = JSON.parse(json);
-    return (data.SPAudioDataType?.[0]?._items || [])
-      .filter((d) => d.coreaudio_input_source != null)
-      .map((d) => d.coreaudio_device_name || d._name);
+    execSync("pactl --version", { stdio: "ignore", timeout: 3000 });
+    return "pulseaudio";
   } catch {
-    return [];
+    return "default";
   }
+}
+
+// Input device descriptors: name is the value passed to sox, label is shown in the UI.
+export function parsePactlSources(jsonText) {
+  const data = JSON.parse(jsonText);
+  return (Array.isArray(data) ? data : [])
+    .filter((s) => s?.name && !s.name.endsWith(".monitor"))
+    .map((s) => ({
+      name: s.name,
+      label: s.description ? `${s.description} (${s.name})` : s.name,
+    }));
+}
+
+export function parsePactlSourcesShort(text) {
+  return text
+    .split("\n")
+    .map((line) => line.trim().split(/\s+/)[1])
+    .filter((name) => name && !name.endsWith(".monitor"))
+    .map((name) => ({ name, label: name }));
+}
+
+function listInputDevices(backend) {
+  if (backend === "coreaudio") {
+    try {
+      const json = execSync("system_profiler SPAudioDataType -json 2>/dev/null", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      const data = JSON.parse(json);
+      return (data.SPAudioDataType?.[0]?._items || [])
+        .filter((d) => d.coreaudio_input_source != null)
+        .map((d) => {
+          const name = d.coreaudio_device_name || d._name;
+          return { name, label: name };
+        });
+    } catch {
+      return [];
+    }
+  }
+  if (backend === "pulseaudio") {
+    try {
+      const json = execSync("pactl -f json list sources 2>/dev/null", {
+        encoding: "utf-8",
+        timeout: 5000,
+      });
+      return parsePactlSources(json);
+    } catch {
+      try {
+        const out = execSync("pactl list sources short 2>/dev/null", {
+          encoding: "utf-8",
+          timeout: 5000,
+        });
+        return parsePactlSourcesShort(out);
+      } catch {
+        return [];
+      }
+    }
+  }
+  return [];
+}
+
+export function buildRecordArgs(backend, mic) {
+  if (backend === "pulseaudio") return ["-t", "pulseaudio", mic || "default"];
+  if (backend === "coreaudio" && mic) return ["-t", "coreaudio", mic];
+  return ["-d"];
 }
 
 // ---- Recording state and control ----
@@ -115,7 +178,7 @@ function forceKillSox(logger) {
   } catch {}
 }
 
-function startRecording(kv, toast, logger) {
+function startRecording(kv, backend, toast, logger) {
   if (soxProc) {
     logger?.log("STT", "Start recording skipped: sox already running", "debug");
     return;
@@ -129,8 +192,12 @@ function startRecording(kv, toast, logger) {
 
   soxStderr = "";
   const mic = kv.get("stt.mic", "") || null;
-  const inputArgs = mic ? ["-t", "coreaudio", mic] : ["-d"];
-  logger?.log("STT", `Starting recording mic=${mic || "system default"}`, "debug");
+  const inputArgs = buildRecordArgs(backend, mic);
+  logger?.log(
+    "STT",
+    `Starting recording backend=${backend} mic=${mic || "system default"}`,
+    "debug",
+  );
 
   soxProc = spawn(
     "sox",
@@ -476,6 +543,8 @@ async function doTranscribePipeline(
 export function registerSTT(api, kv, complete, prompts, opts, logger) {
   const client = api.client;
   const systemPrompt = prompts?.stt || STT_SYSTEM_PROMPT;
+  const backend = detectAudioBackend();
+  logger?.log("STT", `Audio backend=${backend}`, "debug");
   function toast(message, variant = "info") {
     api.ui.toast({ message, variant, duration: 3000 });
   }
@@ -517,7 +586,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           toast("Stopping, transcribing...");
           doTranscribePipeline(kv, complete, client, toast, systemPrompt, false, logger);
         } else {
-          startRecording(kv, toast, logger);
+          startRecording(kv, backend, toast, logger);
           if (recording) toast("Recording... press again to transcribe");
         }
       },
@@ -609,7 +678,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       slash: { name: "stt-mic" },
       onSelect() {
         const current = kv.get("stt.mic", "");
-        const devices = listInputDevices();
+        const devices = listInputDevices(backend);
         if (devices.length === 0) {
           toast("No input devices found");
           return;
@@ -628,12 +697,12 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
                   api.ui.dialog.clear();
                 },
               },
-              ...devices.map((name) => ({
-                title: name,
-                value: name,
+              ...devices.map((d) => ({
+                title: d.label,
+                value: d.name,
                 onSelect() {
-                  kv.set("stt.mic", name);
-                  toast(`Mic: ${name}`);
+                  kv.set("stt.mic", d.name);
+                  toast(`Mic: ${d.label}`);
                   api.ui.dialog.clear();
                 },
               })),

--- a/test/stt.test.js
+++ b/test/stt.test.js
@@ -2,10 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  buildAudioHint,
   buildOpenRouterTranscriptionRequest,
   buildRecordArgs,
   buildWhisperArgs,
   isOpenRouterEndpoint,
+  isWSL,
   parsePactlSources,
   parsePactlSourcesShort,
 } from "../lib/stt.js";
@@ -70,6 +72,42 @@ test("builds sox record args per audio backend", () => {
   ]);
   assert.deepEqual(buildRecordArgs("coreaudio", null), ["-d"]);
   assert.deepEqual(buildRecordArgs("default", null), ["-d"]);
+});
+
+test("builds audio hints per backend and server state", () => {
+  assert.match(
+    buildAudioHint({ backend: "pulseaudio", serverOk: false, isWsl: true }),
+    /wsl --shutdown/,
+  );
+  assert.match(
+    buildAudioHint({ backend: "pulseaudio", serverOk: false, isWsl: false }),
+    /PipeWire\/PulseAudio/,
+  );
+  assert.match(
+    buildAudioHint({ backend: "pulseaudio", serverOk: true, isWsl: false }),
+    /input source configuration/,
+  );
+  assert.equal(
+    buildAudioHint({ backend: "coreaudio", serverOk: false, isWsl: false }),
+    "No input devices found",
+  );
+});
+
+test("detects WSL via environment variables", () => {
+  const savedDistro = process.env.WSL_DISTRO_NAME;
+  const savedInterop = process.env.WSL_INTEROP;
+  try {
+    delete process.env.WSL_DISTRO_NAME;
+    delete process.env.WSL_INTEROP;
+    assert.equal(isWSL(), false);
+    process.env.WSL_DISTRO_NAME = "Ubuntu";
+    assert.equal(isWSL(), true);
+  } finally {
+    if (savedDistro === undefined) delete process.env.WSL_DISTRO_NAME;
+    else process.env.WSL_DISTRO_NAME = savedDistro;
+    if (savedInterop === undefined) delete process.env.WSL_INTEROP;
+    else process.env.WSL_INTEROP = savedInterop;
+  }
 });
 
 test("builds whisper-cli args with language", () => {

--- a/test/stt.test.js
+++ b/test/stt.test.js
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   buildOpenRouterTranscriptionRequest,
   buildRecordArgs,
+  buildWhisperArgs,
   isOpenRouterEndpoint,
   parsePactlSources,
   parsePactlSourcesShort,
@@ -69,4 +70,27 @@ test("builds sox record args per audio backend", () => {
   ]);
   assert.deepEqual(buildRecordArgs("coreaudio", null), ["-d"]);
   assert.deepEqual(buildRecordArgs("default", null), ["-d"]);
+});
+
+test("builds whisper-cli args with language", () => {
+  assert.deepEqual(buildWhisperArgs("/models/ggml.bin", "/tmp/a.wav", "zh"), [
+    "-m",
+    "/models/ggml.bin",
+    "-f",
+    "/tmp/a.wav",
+    "-l",
+    "zh",
+    "-np",
+    "-nt",
+  ]);
+  assert.deepEqual(buildWhisperArgs("/models/ggml.bin", "/tmp/a.wav", null), [
+    "-m",
+    "/models/ggml.bin",
+    "-f",
+    "/tmp/a.wav",
+    "-l",
+    "auto",
+    "-np",
+    "-nt",
+  ]);
 });

--- a/test/stt.test.js
+++ b/test/stt.test.js
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildOpenRouterTranscriptionRequest, isOpenRouterEndpoint } from "../lib/stt.js";
+import {
+  buildOpenRouterTranscriptionRequest,
+  buildRecordArgs,
+  isOpenRouterEndpoint,
+  parsePactlSources,
+  parsePactlSourcesShort,
+} from "../lib/stt.js";
 
 test("detects OpenRouter STT endpoints", () => {
   assert.equal(isOpenRouterEndpoint("https://openrouter.ai/api/v1"), true);
@@ -30,4 +36,37 @@ test("builds OpenRouter STT requests as JSON with base64 audio", () => {
       format: "wav",
     },
   });
+});
+
+test("parses pactl JSON sources and filters out monitors", () => {
+  const json = JSON.stringify([
+    { name: "RDPSink.monitor", description: "Monitor of RDP Sink" },
+    { name: "RDPSource", description: "RDP Source" },
+    { name: "alsa_input.usb-mic" },
+  ]);
+  assert.deepEqual(parsePactlSources(json), [
+    { name: "RDPSource", label: "RDP Source (RDPSource)" },
+    { name: "alsa_input.usb-mic", label: "alsa_input.usb-mic" },
+  ]);
+});
+
+test("parses pactl short sources and filters out monitors", () => {
+  const short = [
+    "1\tRDPSink.monitor\tmodule-rdp-sink.c\ts16le 2ch 44100Hz\tSUSPENDED",
+    "2\tRDPSource\tmodule-rdp-source.c\ts16le 1ch 44100Hz\tSUSPENDED",
+    "",
+  ].join("\n");
+  assert.deepEqual(parsePactlSourcesShort(short), [{ name: "RDPSource", label: "RDPSource" }]);
+});
+
+test("builds sox record args per audio backend", () => {
+  assert.deepEqual(buildRecordArgs("pulseaudio", "RDPSource"), ["-t", "pulseaudio", "RDPSource"]);
+  assert.deepEqual(buildRecordArgs("pulseaudio", null), ["-t", "pulseaudio", "default"]);
+  assert.deepEqual(buildRecordArgs("coreaudio", "USB Microphone"), [
+    "-t",
+    "coreaudio",
+    "USB Microphone",
+  ]);
+  assert.deepEqual(buildRecordArgs("coreaudio", null), ["-d"]);
+  assert.deepEqual(buildRecordArgs("default", null), ["-d"]);
 });


### PR DESCRIPTION
## feat: enhance audio backend detection for Linux/WSL2 and input device handling

### Why
The STT pipeline previously assumed macOS CoreAudio for both recording and device listing. This prevented **Linux** and **WSL2** users from selecting the correct microphone, and caused sox to fail or record from the wrong device when no CoreAudio backend was available. A single cross-platform audio backend abstraction was needed.

### What Changes
- `README.md`: rewrote the Speech-to-text section into macOS and Linux/WSL2 subsections. Added microphone verification steps, Linux CPU/CUDA build instructions with a GPU architecture table, a smoke-test section, and updated /stt-mic and STT pipeline descriptions.
- `lib/stt.js`:
  - Added detectAudioBackend() to choose coreaudio on macOS, **pulseaudio when pactl exists**, or the **sox default** otherwise.
  - Added parsePactlSources() and parsePactlSourcesShort() to parse pactl output and exclude .monitor sources.
  - Refactored listInputDevices() to return { name, label } descriptors per backend.
  - Added buildRecordArgs(backend, mic) to generate the correct sox -t arguments for each backend.
  - Added backend logging at recording start and registerSTT time.
  - Added medium-q5_0 to the model registry.
- test/stt.test.js: added tests for parsePactlSources, parsePactlSourcesShort, and buildRecordArgs.

### Capabilities
- macOS users continue to use CoreAudio input devices with no behavior change.
- **Linux and WSL2** users can now select real **PulseAudio** input sources via /stt-mic.
- Recording automatically uses the pulseaudio sox driver on Linux when pactl is present, falling back to the default sox device otherwise.
- Users can verify the active whisper.cpp backend (METAL / CUDA / CPU) and expected performance from the README.

### Impact
- Improved first-run experience on Linux/WSL2 with clear setup and verification steps.
- More reliable microphone capture across platforms by matching the sox driver to the OS audio stack.
- Better diagnostics via backend-aware logging.
- No breaking changes for existing macOS users; stored stt.mic values remain valid.

## feat: add support for selecting transcription language in STT

### Why:
`whisper-cli` defaults to `-l en`, so the plugin silently forced English decoding for all users — non-English speech was transcribed poorly with no way to fix it.

### What Changes:
- New exported buildWhisperArgs() pure function assembles whisper-cli args with a language flag
- Language resolution follows the existing pattern: kv("stt.language") overrides options.sttLanguage, falling back to auto
- New **/stt-language** command with a curated language picker (auto + 11 common languages)
- Unknown language codes are detected from stderr and reported as errors (whisper-cli exits 0 even on invalid languages)
- Tests added for buildWhisperArgs; README and command docs updated

### Capabilities:
- Users can set any whisper.cpp language code via the sttLanguage plugin option, or switch at runtime among common languages via /stt-language
- Out of the box, auto-detection now works for any spoken language
- Invalid language codes surface a clear error instead of a misleading "no speech detected"

### Impact:
- Non-English users get correct transcription with zero configuration
- Existing English users see a minor behavior change (**default is now auto instead of en**): a small language-detection overhead and occasional misdetection on very short clips, recoverable via /stt-language or sttLanguage
- STT API transcription path is unaffected (local whisper-cli only)

## feat: add WSL audio server diagnostics and hints for recording failures

### Why
On WSL2, WSLg's PulseAudio server can wedge: its listen backlog (hardcoded to 5 in PulseAudio) fills up with orphaned connections that are never accept()ed, so every new client gets Connection refused. The plugin made this failure invisible at three points:
- detectAudioBackend() probes with pactl --version, which never connects to the server and reports "pulseaudio" even when the server is dead
- /stt-mic swallowed listing errors and toasted a misleading "No input devices found"
- startRecording surfaced only sox's raw, cryptic stderr (FAIL formats: can't open input...)
Users on WSL had no way to tell "no microphone exists" apart from "the audio server is stuck, restart WSL".

### What Changes
- lib/stt.js — new diagnostics block:
- isWSL() (exported): detects WSL via WSL_DISTRO_NAME / WSL_INTEROP
- pulseServerHealth(): probes with pactl info, which actually connects to the server (unlike pactl --version)
- buildAudioHint() (exported, pure): builds a user-facing hint per backend / server state / WSL-or-not; on WSL it explicitly advises wsl --shutdown on Windows
- audioFailureSuffix() (internal): appends the hint to recording-failure toasts when the PulseAudio server is unreachable
- Wiring: /stt-mic's empty-device branch now health-checks first and toasts/logs the hint; both sox error and non-zero exit paths in startRecording append the same hint. detectAudioBackend() is unchanged — "pulse stack exists" and "server is healthy" stay separate concerns
- test/stt.test.js — 2 new tests: buildAudioHint branch coverage (WSL / non-WSL / healthy / non-pulse) and isWSL() env detection with env restoration
- README.md — new "WSL2 audio troubleshooting" note: no /dev/snd is normal, Connection refused → wsl --shutdown, Windows microphone privacy settings, wsl --update (plus oxfmt whitespace-only reformat of two existing tables)

### Capabilities
- Users hitting a dead WSLg audio server now see an actionable message — "Audio server unreachable. On WSL, WSLg's PulseAudio may be stuck - run wsl --shutdown on Windows, then reopen Ubuntu" — instead of "No input devices found" or raw sox stderr
- Non-WSL Linux users get a corresponding PipeWire/PulseAudio service hint; a reachable server with zero sources gets a "check your audio input source configuration" hint
- Diagnosis runs lazily (only on failure paths), with a 3 s timeout, so the happy path is untouched

### Impact
- Behavior change is additive: only error/empty-result paths change; recording, device listing, and backend detection on healthy systems are byte-for-byte identical
- No new dependencies, no config or API surface changes; 16/16 tests pass, npm run check clean
- Verified live on a wedged WSLg instance: the hint correctly triggers with isWSL: true, serverOk: false
- Full audio recovery itself still requires the user to run wsl --shutdown on Windows — the plugin now tells them exactly that