### PR TITLE
feat: make LLM normalization optional for S

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@
 Speech-to-text and text-to-speech plugin for [OpenCode](https://opencode.ai/).
 
 Record voice prompts with local whisper transcription, hear assistant responses
-spoken aloud via Piper TTS. Both directions use an LLM to normalize text for
-natural speech (fixing homophones, splitting camelCase identifiers, summarizing
-code-heavy responses, etc.).
+spoken aloud via Piper TTS. An LLM can optionally normalize text for natural
+speech (fixing homophones, splitting camelCase identifiers, summarizing
+code-heavy responses, etc.). Speech-to-text works without an LLM: raw whisper
+transcription is used directly when no `endpoint`/`model` is configured.
 
 ## Install
 
 Add to your `tui.json` (create at `~/.config/opencode/tui.json` if it doesn't
-exist). You must configure at least `endpoint` and `model`:
+exist). An LLM `endpoint` and `model` are optional and only needed for text
+normalization. For speech-to-text alone you can enable the plugin with an empty
+config (or just `sttLanguage`):
 
 > [!NOTE]
 > **Clobbering default keybinds.** This plugin uses `ctrl+r` for voice
@@ -228,10 +231,12 @@ curl -L -o ~/.local/share/piper-voices/en_US-ryan-high.onnx.json \
 
 ### LLM endpoint
 
-An OpenAI-compatible LLM endpoint is required for text normalization. For
-speech-to-text it cleans up whisper output (punctuation, filler words, software
-engineering homophones). For text-to-speech it converts markdown into natural
-spoken text.
+An OpenAI-compatible LLM endpoint is optional. When configured it normalizes
+text: for speech-to-text it cleans up whisper output (punctuation, filler words,
+software engineering homophones); for text-to-speech it converts markdown into
+natural spoken text. Without `endpoint`/`model`, speech-to-text still works and
+uses the raw whisper transcription directly. Text-to-speech requires the LLM
+endpoint and reports unavailability if it is not configured.
 
 Configure your endpoint in `tui.json` via plugin options. Any OpenAI-compatible
 endpoint works (Anthropic, OpenAI, Ollama, vLLM, LM Studio, etc.). The `apiKeyEnv`
@@ -268,8 +273,8 @@ For unauthenticated local endpoints (e.g. Ollama):
 }
 ```
 
-- `endpoint` _(required)_ - OpenAI-compatible base URL
-- `model` _(required)_ - model name sent to `/chat/completions`
+- `endpoint` _(optional)_ - OpenAI-compatible base URL. Required together with `model` for LLM normalization.
+- `model` _(optional)_ - model name sent to `/chat/completions`. Required together with `endpoint` for LLM normalization.
 - `apiKeyEnv` _(optional)_ - environment variable containing the API key
 - `maxTokens` _(optional)_ - maximum completion tokens for normalization calls
 - `reasoningEffort` _(optional)_ - reasoning level for models that support it
@@ -381,9 +386,10 @@ then `s`.
    Linux when `pactl` is available, sox default device otherwise)
 2. `whisper-cli` transcribes locally using a ggml model, or an OpenAI-compatible
    API endpoint if `sttEndpoint` is configured
-3. LLM normalizes the transcription: fixes punctuation, removes filler words,
-   corrects software engineering homophones ("Jason" to "JSON", "bullion" to
-   "boolean", etc.)
+3. If an LLM `endpoint`/`model` is configured, it normalizes the transcription:
+   fixes punctuation, removes filler words, corrects software engineering
+   homophones ("Jason" to "JSON", "bullion" to "boolean", etc.). Without an LLM,
+   the raw transcription is used directly
 4. Cleaned text is appended to the OpenCode prompt, or submitted immediately
    when `/stt-submit` is used. If normalization fails (e.g. LLM endpoint
    unreachable), the raw transcription is used as a fallback so you never lose

--- a/index.js
+++ b/index.js
@@ -13,6 +13,9 @@
 // Configuration via tui.json plugin options:
 //   ["opencode-voice", { "endpoint": "...", "model": "...", "apiKeyEnv": "..." }]
 //
+// `endpoint`/`model` are optional: without them STT uses the raw whisper
+// transcription directly (no LLM normalization).
+//
 // Runtime state (model, mic, voice, tts mode) persisted via api.kv.
 //
 // Commands:
@@ -57,7 +60,7 @@ export default {
     const { kv } = api;
     const logger = createLogger(api.client);
     logger.log("plugin", "Initializing", "debug");
-    const { complete } = createClient(options, logger);
+    const { complete, isConfigured } = createClient(options, logger);
 
     const prompts = {
       stt: loadPromptFile(options?.sttPrompt, logger, "STT"),
@@ -65,7 +68,7 @@ export default {
       ttsManual: loadPromptFile(options?.ttsManualPrompt, logger, "TTS manual"),
     };
 
-    const sttCommands = registerSTT(api, kv, complete, prompts, options, logger);
+    const sttCommands = registerSTT(api, kv, complete, prompts, options, logger, isConfigured);
     const ttsCommands = registerTTS(api, kv, complete, prompts, logger);
 
     api.command.register(() => [...sttCommands, ...ttsCommands]);

--- a/lib/llm-client.js
+++ b/lib/llm-client.js
@@ -53,7 +53,7 @@ function wait(ms) {
  *
  * @param {object} [pluginOptions] - Static config from tui.json plugin options
  * @param {{ log?: (scope: string, message: string, level?: string) => void }} [logger]
- * @returns {{ complete: (opts: { system?: string, prompt: string, config?: object }) => Promise<{ text: string | null, error?: string }> }}
+ * @returns {{ complete: (opts: { system?: string, prompt: string, config?: object }) => Promise<{ text: string | null, error?: string }>, isConfigured: boolean }}
  */
 export function createClient(pluginOptions, logger) {
   function getConfig() {
@@ -161,5 +161,8 @@ export function createClient(pluginOptions, logger) {
     return { text: null, error: "LLM request failed after retries" };
   }
 
-  return { complete };
+  return {
+    complete,
+    isConfigured: Boolean(pluginOptions?.endpoint && pluginOptions?.model),
+  };
 }

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -9,6 +9,7 @@ import { getActiveSessionTitle } from "./session.js";
 let sttApiEndpoint = null;
 let sttApiModel = null;
 let sttApiKeyEnv = null;
+let hasLLM = true;
 
 const WAV_FILENAME = "opencode-stt.wav";
 let tmpDir = "/tmp";
@@ -584,25 +585,28 @@ async function doTranscribePipeline(
       return;
     }
 
-    toast("Normalizing...");
-    const sessionTitle = await getActiveSessionTitle(client);
-    const llmResult = await normalizeTranscription(
-      complete,
-      result.text,
-      sessionTitle,
-      systemPrompt,
-      logger,
-    );
+    let finalText = result.text;
+    if (hasLLM) {
+      toast("Normalizing...");
+      const sessionTitle = await getActiveSessionTitle(client);
+      const llmResult = await normalizeTranscription(
+        complete,
+        result.text,
+        sessionTitle,
+        systemPrompt,
+        logger,
+      );
 
-    if (!llmResult.text) {
-      logger?.log("STT", `Normalization failed, using raw input: ${llmResult.error}`, "warn");
-      toast(`Normalization failed, using raw input: ${llmResult.error}`, "warning");
-      await appendTranscription(client, result.text, submit);
-      return;
+      if (!llmResult.text) {
+        logger?.log("STT", `Normalization failed, using raw input: ${llmResult.error}`, "warn");
+        toast(`Normalization failed, using raw input: ${llmResult.error}`, "warning");
+      } else {
+        finalText = llmResult.text;
+      }
     }
 
-    await appendTranscription(client, llmResult.text, submit);
-    logger?.log("STT", `Pipeline completed normalizedChars=${llmResult.text.length}`, "debug");
+    await appendTranscription(client, finalText, submit);
+    logger?.log("STT", `Pipeline completed chars=${finalText.length}`, "debug");
     toast(submit ? "Transcription submitted" : "Transcription added to prompt", "success");
   } catch (err) {
     logger?.log("STT", `Pipeline error: ${err.message}`, "error");
@@ -615,11 +619,12 @@ async function doTranscribePipeline(
 
 // ---- Public API for TUI plugin ----
 
-export function registerSTT(api, kv, complete, prompts, opts, logger) {
+export function registerSTT(api, kv, complete, prompts, opts, logger, llmConfigured = true) {
   const client = api.client;
   const systemPrompt = prompts?.stt || STT_SYSTEM_PROMPT;
   const backend = detectAudioBackend();
   logger?.log("STT", `Audio backend=${backend}`, "debug");
+  hasLLM = llmConfigured;
   function toast(message, variant = "info") {
     api.ui.toast({ message, variant, duration: 3000 });
   }

--- a/test/llm-client.test.js
+++ b/test/llm-client.test.js
@@ -33,6 +33,16 @@ test("returns error when model is not configured", async () => {
   });
 });
 
+test("reports isConfigured only when endpoint and model are both set", () => {
+  assert.equal(createClient().isConfigured, false);
+  assert.equal(createClient({ endpoint: "https://example.test/v1" }).isConfigured, false);
+  assert.equal(createClient({ model: "test-model" }).isConfigured, false);
+  assert.equal(
+    createClient({ endpoint: "https://example.test/v1", model: "test-model" }).isConfigured,
+    true,
+  );
+});
+
 test("sends chat completions requests with reasoning_effort when configured", async () => {
   const previousKey = process.env.TEST_LLM_API_KEY;
   const previousFetch = globalThis.fetch;


### PR DESCRIPTION
Description:
## Summary

LLM normalization is now optional in the STT pipeline. Speech-to-text works with
no `endpoint`/`model` configured, using the raw Whisper transcription directly.

Previously the plugin required an LLM `endpoint`/`model`, otherwise every
transcription warned or errored. Now:

- If `endpoint` **and** `model` are configured — normalization runs as before.
- If LLM config is absent — the raw Whisper transcription is used directly.
  This is a supported mode, not an error/fallback, and produces no warnings.
- Real LLM failures (endpoint configured but API down) keep the existing
  raw-input fallback.
- TTS behavior is unchanged (still reports unavailability if LLM is not configured).

The minimal config for STT-only is now just:

```json
["@renjfk/opencode-voice", {}]
```

## Changes

- `lib/stt.js` — skip LLM normalization when it is not configured.
- `lib/llm-client.js` — `createClient` now returns `isConfigured` (endpoint + model).
- `index.js` — thread `isConfigured` into `registerSTT`.
- `test/llm-client.test.js` — test for `isConfigured`.
- `README.md` — document optional LLM normalization.

## Verification

- `npm test` — 17 pass
- `npm run check` — clean