### PR TITLE
feat: show live progress toasts for recording and transcription

### DIFF
--- a/lib/stt.js
+++ b/lib/stt.js
@@ -293,14 +293,16 @@ function startRecording(kv, backend, toast, logger, trimSilence = true) {
       `sox exited code=${code} stderr=${soxStderr.trim()}`,
       code === 0 || code === null ? "debug" : "warn",
     );
-    if (recording && code !== 0 && code !== null && !processing) {
+    if (recording && !processing) {
       recording = false;
       stopRecordingStatus();
-      const errLine = soxStderr.trim().split("\n").pop();
-      toast(
-        `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
-        "error",
-      );
+      if (code !== 0 && code !== null) {
+        const errLine = soxStderr.trim().split("\n").pop();
+        toast(
+          `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
+          "error",
+        );
+      }
     }
   });
 

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -218,6 +218,7 @@ let soxProc = null;
 let soxStderr = "";
 let recording = false;
 let processing = false;
+let stopRecordStatus = null;
 
 function forceKillSox(logger) {
   if (soxProc) {
@@ -230,6 +231,14 @@ function forceKillSox(logger) {
   try {
     execSync("pkill -9 -f 'sox.*opencode-stt'", { stdio: "ignore" });
   } catch {}
+  stopRecordingStatus();
+}
+
+function stopRecordingStatus() {
+  if (stopRecordStatus) {
+    stopRecordStatus();
+    stopRecordStatus = null;
+  }
 }
 
 function startRecording(kv, backend, toast, logger, trimSilence = true) {
@@ -272,6 +281,7 @@ function startRecording(kv, backend, toast, logger, trimSilence = true) {
     logger?.log("STT", `Recording failed: ${err.message}`, "error");
     if (recording) {
       recording = false;
+      stopRecordingStatus();
       toast(`Recording failed: ${err.message}${audioFailureSuffix(backend)}`, "error");
     }
   });
@@ -285,6 +295,7 @@ function startRecording(kv, backend, toast, logger, trimSilence = true) {
     );
     if (recording && code !== 0 && code !== null && !processing) {
       recording = false;
+      stopRecordingStatus();
       const errLine = soxStderr.trim().split("\n").pop();
       toast(
         `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
@@ -294,6 +305,9 @@ function startRecording(kv, backend, toast, logger, trimSilence = true) {
   });
 
   recording = true;
+  stopRecordStatus = startStatusToast(toast, "Recording... press again to transcribe", {
+    unit: "recorded",
+  });
 }
 
 function stopRecording(logger) {
@@ -555,6 +569,20 @@ async function appendTranscription(client, text, submit) {
   }
 }
 
+// Keeps a progress toast visible while an async stage runs. Toasts cannot be
+// dismissed programmatically, so we re-fire the toast every second with elapsed
+// seconds (starting at 0s) until `stop()` is called.
+function startStatusToast(toast, message, { unit = "" } = {}) {
+  const started = Date.now();
+  const render = () => {
+    const seconds = Math.floor((Date.now() - started) / 1000);
+    toast(`${message} (${seconds}s${unit ? ` ${unit}` : ""})`);
+  };
+  render();
+  const timer = setInterval(render, 1000);
+  return () => clearInterval(timer);
+}
+
 async function doTranscribePipeline(
   kv,
   complete,
@@ -569,9 +597,15 @@ async function doTranscribePipeline(
     logger?.log("STT", `Pipeline started submit=${submit}`, "debug");
     stopRecording(logger);
     await waitForSoxExit(logger);
+    stopRecordingStatus();
 
-    toast("Transcribing...");
-    const result = sttApiEndpoint ? await transcribeApi(kv, logger) : await transcribe(kv, logger);
+    const stopStatus = startStatusToast(toast, "Transcribing...");
+    let result;
+    try {
+      result = sttApiEndpoint ? await transcribeApi(kv, logger) : await transcribe(kv, logger);
+    } finally {
+      stopStatus();
+    }
 
     if (result.error) {
       logger?.log("STT", `Transcription failed: ${result.error}`, "error");
@@ -584,15 +618,20 @@ async function doTranscribePipeline(
       return;
     }
 
-    toast("Normalizing...");
-    const sessionTitle = await getActiveSessionTitle(client);
-    const llmResult = await normalizeTranscription(
-      complete,
-      result.text,
-      sessionTitle,
-      systemPrompt,
-      logger,
-    );
+    const stopNormStatus = startStatusToast(toast, "Normalizing...");
+    let llmResult;
+    try {
+      const sessionTitle = await getActiveSessionTitle(client);
+      llmResult = await normalizeTranscription(
+        complete,
+        result.text,
+        sessionTitle,
+        systemPrompt,
+        logger,
+      );
+    } finally {
+      stopNormStatus();
+    }
 
     if (!llmResult.text) {
       logger?.log("STT", `Normalization failed, using raw input: ${llmResult.error}`, "warn");
@@ -610,6 +649,7 @@ async function doTranscribePipeline(
   } finally {
     processing = false;
     recording = false;
+    stopRecordingStatus();
   }
 }
 
@@ -667,7 +707,6 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           doTranscribePipeline(kv, complete, client, toast, systemPrompt, false, logger);
         } else {
           startRecording(kv, backend, toast, logger, opts?.trimSilence);
-          if (recording) toast("Recording... press again to transcribe");
         }
       },
     },


### PR DESCRIPTION
## Summary

The STT pipeline now keeps a live progress toast visible while it is working.
Previously the status toasts ("Recording...", "Transcribing...") auto-dismissed
after a few seconds, so during a long local Whisper decode (30-40s) there was no
visible feedback and it looked like the plugin was stuck.

Now each stage shows an elapsed-seconds counter, refreshed every second, starting
at 0s:

- Recording: `Recording... press again to transcribe (0s recorded)`, `(5s recorded)`, ...
- Transcribing: `Transcribing... (0s)`, `(8s)`, ...
- Normalizing (when an LLM is configured): `Normalizing... (0s)`, `(3s)`, ...

The toast stops as soon as the stage finishes.

## Implementation note

`api.ui.toast` exposes no dismiss handle, so a toast cannot be cleared
programmatically. Instead the message is re-fired every second with the elapsed
time, which keeps it continuously visible for the duration of the stage.

## Changes

- `lib/stt.js` — `startStatusToast` helper; persistent status for recording,
  transcribing, and normalizing; stop the recording status on all exit paths
  (cancel, sox error/exit, pipeline end).

## Verification

- `npm test` — 17 pass
- `npm run check` — clean