### PR TITLE
feat(stt): keep recording toast visible until recording stops

### DIFF
--- a/lib/stt.js
+++ b/lib/stt.js
@@ -245,13 +245,12 @@ export function isRecordingToastActive() {
 
 export function showRecordingToast() {
   clearRecordingToast();
-  if (recordingToastFn) {
-    recordingToastFn({
-      message: RECORDING_TOAST_MESSAGE,
-      variant: "info",
-      duration: RECORDING_TOAST_DURATION,
-    });
-  }
+  if (!recordingToastFn) return;
+  recordingToastFn({
+    message: RECORDING_TOAST_MESSAGE,
+    variant: "info",
+    duration: RECORDING_TOAST_DURATION,
+  });
   recordingToastTimer = setInterval(() => {
     if (recordingToastFn) {
       recordingToastFn({
@@ -343,6 +342,8 @@ function startRecording(kv, backend, toast, logger) {
           `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
           "error",
         );
+      } else {
+        toast("Recording stopped unexpectedly", "warning");
       }
     }
   });
@@ -680,7 +681,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
   }
 
   __setRecordingToastFn((input) => api.ui.toast(input));
-  api.lifecycle?.onDispose?.(() => clearRecordingToast());
+  api.lifecycle?.onDispose?.(() => __clearRecordingToastState());
 
   if (opts?.sttEndpoint) {
     sttApiEndpoint = opts.sttEndpoint;

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -219,6 +219,57 @@ let soxStderr = "";
 let recording = false;
 let processing = false;
 
+// ---- Sticky recording toast (Option A: polling to simulate persistence) ----
+
+let recordingToastTimer = null;
+let recordingToastFn = null;
+const RECORDING_TOAST_MESSAGE = "🎙 Recording · Ctrl+R to stop";
+const RECORDING_TOAST_DURATION = 3000;
+const RECORDING_TOAST_INTERVAL = 2500;
+
+export function __setRecordingToastFn(fn) {
+  recordingToastFn = fn;
+}
+
+export function __clearRecordingToastState() {
+  if (recordingToastTimer) {
+    clearInterval(recordingToastTimer);
+    recordingToastTimer = null;
+  }
+  recordingToastFn = null;
+}
+
+export function isRecordingToastActive() {
+  return recordingToastTimer !== null;
+}
+
+export function showRecordingToast() {
+  clearRecordingToast();
+  if (recordingToastFn) {
+    recordingToastFn({
+      message: RECORDING_TOAST_MESSAGE,
+      variant: "info",
+      duration: RECORDING_TOAST_DURATION,
+    });
+  }
+  recordingToastTimer = setInterval(() => {
+    if (recordingToastFn) {
+      recordingToastFn({
+        message: RECORDING_TOAST_MESSAGE,
+        variant: "info",
+        duration: RECORDING_TOAST_DURATION,
+      });
+    }
+  }, RECORDING_TOAST_INTERVAL);
+}
+
+export function clearRecordingToast() {
+  if (recordingToastTimer) {
+    clearInterval(recordingToastTimer);
+    recordingToastTimer = null;
+  }
+}
+
 function forceKillSox(logger) {
   if (soxProc) {
     try {
@@ -271,6 +322,7 @@ function startRecording(kv, backend, toast, logger) {
     logger?.log("STT", `Recording failed: ${err.message}`, "error");
     if (recording) {
       recording = false;
+      clearRecordingToast();
       toast(`Recording failed: ${err.message}${audioFailureSuffix(backend)}`, "error");
     }
   });
@@ -282,13 +334,16 @@ function startRecording(kv, backend, toast, logger) {
       `sox exited code=${code} stderr=${soxStderr.trim()}`,
       code === 0 || code === null ? "debug" : "warn",
     );
-    if (recording && code !== 0 && code !== null && !processing) {
+    if (recording && !processing) {
       recording = false;
-      const errLine = soxStderr.trim().split("\n").pop();
-      toast(
-        `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
-        "error",
-      );
+      clearRecordingToast();
+      if (code !== 0 && code !== null) {
+        const errLine = soxStderr.trim().split("\n").pop();
+        toast(
+          `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
+          "error",
+        );
+      }
     }
   });
 
@@ -564,6 +619,7 @@ async function doTranscribePipeline(
   logger,
 ) {
   processing = true;
+  clearRecordingToast();
   try {
     logger?.log("STT", `Pipeline started submit=${submit}`, "debug");
     stopRecording(logger);
@@ -623,6 +679,9 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
     api.ui.toast({ message, variant, duration: 3000 });
   }
 
+  __setRecordingToastFn((input) => api.ui.toast(input));
+  api.lifecycle?.onDispose?.(() => clearRecordingToast());
+
   if (opts?.sttEndpoint) {
     sttApiEndpoint = opts.sttEndpoint;
     sttApiModel = opts.sttModel || "whisper-large-v3-turbo";
@@ -662,11 +721,12 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           return;
         }
         if (recording) {
+          clearRecordingToast();
           toast("Stopping, transcribing...");
           doTranscribePipeline(kv, complete, client, toast, systemPrompt, false, logger);
         } else {
           startRecording(kv, backend, toast, logger);
-          if (recording) toast("Recording... press again to transcribe");
+          if (recording) showRecordingToast();
         }
       },
     },
@@ -687,6 +747,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           toast("No recording in progress", "warning");
           return;
         }
+        clearRecordingToast();
         toast("Stopping, transcribing...");
         doTranscribePipeline(kv, complete, client, toast, systemPrompt, true, logger);
       },
@@ -699,6 +760,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       onSelect() {
         if (recording) {
           recording = false;
+          clearRecordingToast();
           forceKillSox(logger);
           logger?.log("STT", "Recording cancelled", "debug");
           toast("Recording cancelled");


### PR DESCRIPTION
## Summary
Keep the recording indicator visible for the entire `recording === true` window. Previously `api.ui.toast({duration:3000})` faded after 3s even while `sox` was still capturing, leaving no feedback for long recordings.

## ASCII — Before / After

**Before (3s fade):**
```
Ctrl+R
  │
  ▼
┌─────────────────────┐
│ 🎙 Recording        │  ── 3s ──►  gone (still recording!)
└─────────────────────┘
```

**After (sticky polling):**
```
Ctrl+R
  │
  ▼
┌─────────────────────────────┐
│ 🎙 Recording · leader+[ to stop │  poll 2500ms, duration 3000ms
└─────────────────────────────┘
  │ 3s │ 10s │ 30s │ STILL THERE
  ▼
Ctrl+R
  │
  ▼
┌─────────────────────┐
│ ⏳ Transcribing...  │ (normal 3s toast)
└─────────────────────┘
```

Invariant: `recording toast visible ⇔ recording===true`. Cleared on `stt.record` stop, `stt.submit`, `stt.stop` cancel, `sox` `error`/`exit` (including `code 0` unexpected), and `doTranscribePipeline` entry + `lifecycle.onDispose`.

## Changes
- `lib/stt.js:222-350` — `recordingToastTimer`/`recordingToastFn`, `showRecordingToast()`/`clearRecordingToast()`, `isRecordingToastActive()`, `sox.on(error/exit)` + `doTranscribePipeline` + `registerSTT` lifecycle + `forceKillSox` exit `code 0` handling.

## Testing
- `npm run check`/`npm test` pass
- Manual: `Ctrl+R` (now `leader+[` ) → toast stays >10s, second `Ctrl+R`/`<leader>[` → `Transcribing…`, `/stt-stop` → `Recording cancelled`, kill `sox` → error toast + sticky cleared.

## Stack
Base `main`, independent. Next PR `pr/waveform` builds on this.

