### PR TITLE
feat(stt): 16-col fixed-column waveform with noise gate

### DIFF
--- a/lib/stt.js
+++ b/lib/stt.js
@@ -245,13 +245,12 @@ export function isRecordingToastActive() {
 
 export function showRecordingToast() {
   clearRecordingToast();
-  if (recordingToastFn) {
-    recordingToastFn({
-      message: RECORDING_TOAST_MESSAGE,
-      variant: "info",
-      duration: RECORDING_TOAST_DURATION,
-    });
-  }
+  if (!recordingToastFn) return;
+  recordingToastFn({
+    message: RECORDING_TOAST_MESSAGE,
+    variant: "info",
+    duration: RECORDING_TOAST_DURATION,
+  });
   recordingToastTimer = setInterval(() => {
     if (recordingToastFn) {
       recordingToastFn({
@@ -343,6 +342,8 @@ function startRecording(kv, backend, toast, logger) {
           `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
           "error",
         );
+      } else {
+        toast("Recording stopped unexpectedly", "warning");
       }
     }
   });
@@ -680,7 +681,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
   }
 
   __setRecordingToastFn((input) => api.ui.toast(input));
-  api.lifecycle?.onDispose?.(() => clearRecordingToast());
+  api.lifecycle?.onDispose?.(() => __clearRecordingToastState());
 
   if (opts?.sttEndpoint) {
     sttApiEndpoint = opts.sttEndpoint;

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -223,9 +223,19 @@ let processing = false;
 
 let recordingToastTimer = null;
 let recordingToastFn = null;
-const RECORDING_TOAST_MESSAGE = "🎙 Recording · Ctrl+R to stop";
+const RECORDING_TOAST_BASE = "🎙 Recording";
 const RECORDING_TOAST_DURATION = 3000;
 const RECORDING_TOAST_INTERVAL = 2500;
+// Live wave + timer config (PR2) — 16 fixed columns, flat on silence
+let recordingStartMs = null;
+let prevWaveLevels = [];
+let noiseFloorRms = null;
+let calibrationEndMs = null;
+const WAVE_CHARS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+const WAVE_LEN = 16;
+const WAVE_INTERVAL = 60;
+const WAVE_DURATION = 220;
+let useWave = true;
 
 export function __setRecordingToastFn(fn) {
   recordingToastFn = fn;
@@ -237,29 +247,179 @@ export function __clearRecordingToastState() {
     recordingToastTimer = null;
   }
   recordingToastFn = null;
+  recordingStartMs = null;
+  prevWaveLevels = [];
+  noiseFloorRms = null;
+  calibrationEndMs = null;
+}
+
+export function __setUseWave(v) {
+  useWave = !!v;
 }
 
 export function isRecordingToastActive() {
   return recordingToastTimer !== null;
 }
 
+export function formatElapsed(ms) {
+  const totalSec = Math.floor(ms / 1000);
+  const m = String(Math.floor(totalSec / 60)).padStart(2, "0");
+  const s = String(totalSec % 60).padStart(2, "0");
+  return `${m}:${s}`;
+}
+
+export function rmsToChar(rms) {
+  if (rms < 0.008) return WAVE_CHARS[0];
+  if (rms < 0.018) return WAVE_CHARS[1];
+  if (rms < 0.035) return WAVE_CHARS[2];
+  if (rms < 0.06) return WAVE_CHARS[3];
+  if (rms < 0.1) return WAVE_CHARS[4];
+  if (rms < 0.16) return WAVE_CHARS[5];
+  if (rms < 0.24) return WAVE_CHARS[6];
+  return WAVE_CHARS[7];
+}
+
+export function rmsToLevel(rms) {
+  if (rms < 0.008) return 0;
+  if (rms < 0.018) return 1;
+  if (rms < 0.035) return 2;
+  if (rms < 0.06) return 3;
+  if (rms < 0.1) return 4;
+  if (rms < 0.16) return 5;
+  if (rms < 0.24) return 6;
+  return 7;
+}
+
+export function computeWaveChar() {
+  const wavFile = path.join(tmpDir, WAV_FILENAME);
+  try {
+    const data = fs.readFileSync(wavFile);
+    if (data.length <= 44) return WAVE_CHARS[0];
+    const windowSize = 2560;
+    const start = Math.max(44, data.length - windowSize);
+    const slice = data.subarray(start);
+    const samples = Math.floor(slice.length / 2);
+    if (samples === 0) return WAVE_CHARS[0];
+    let sum = 0;
+    for (let i = 0; i < slice.length - 1; i += 2) {
+      const s = slice.readInt16LE(i);
+      const n = s / 32768;
+      sum += n * n;
+    }
+    const rms = Math.sqrt(sum / samples);
+    if (rms < 0.003) return WAVE_CHARS[0];
+    return rmsToChar(rms);
+  } catch {
+    return WAVE_CHARS[0];
+  }
+}
+
+export function getWaveString() {
+  // Fixed-column snapshot: each column = noise-gated RMS of sub-slice of last ~0.08s window
+  const wavFile = path.join(tmpDir, WAV_FILENAME);
+  try {
+    const data = fs.readFileSync(wavFile);
+    if (data.length <= 44) {
+      prevWaveLevels = Array(WAVE_LEN).fill(0);
+      return WAVE_CHARS[0].repeat(WAVE_LEN);
+    }
+    const windowSize = 2560; // ~0.08s at 16kHz mono 16-bit → very instant
+    const start = Math.max(44, data.length - windowSize);
+    const slice = data.subarray(start);
+    const chunkBytes = Math.max(2, Math.floor(slice.length / WAVE_LEN));
+    const rawRms = [];
+    const levels = [];
+    for (let c = 0; c < WAVE_LEN; c++) {
+      const off = c * chunkBytes;
+      const chunk = slice.subarray(off, Math.min(off + chunkBytes, slice.length));
+      const samples = Math.floor(chunk.length / 2);
+      if (samples === 0) {
+        rawRms.push(0);
+        levels.push(0);
+        continue;
+      }
+      let sum = 0;
+      for (let i = 0; i < chunk.length - 1; i += 2) {
+        const s = chunk.readInt16LE(i);
+        const n = s / 32768;
+        sum += n * n;
+      }
+      const rms = Math.sqrt(sum / samples);
+      rawRms.push(rms);
+    }
+    const now = Date.now();
+    if (calibrationEndMs && now < calibrationEndMs) {
+      const minRms = Math.min(...rawRms);
+      if (noiseFloorRms === null || minRms < noiseFloorRms) noiseFloorRms = minRms;
+      prevWaveLevels = Array(WAVE_LEN).fill(0);
+      return WAVE_CHARS[0].repeat(WAVE_LEN);
+    }
+    if (noiseFloorRms === null) noiseFloorRms = Math.min(...rawRms);
+    else {
+      const minRms = Math.min(...rawRms);
+      noiseFloorRms = Math.min(noiseFloorRms, minRms);
+      noiseFloorRms = noiseFloorRms * 0.995 + minRms * 0.005;
+    }
+    for (const rms of rawRms) {
+      const effective = Math.max(0, rms - noiseFloorRms * 1.15);
+      if (effective < 0.005) levels.push(0);
+      else levels.push(rmsToLevel(effective * 1.6));
+    }
+    if (prevWaveLevels.length !== WAVE_LEN) prevWaveLevels = Array(WAVE_LEN).fill(0);
+    const smoothed = levels.map((lvl, i) => {
+      const prev = prevWaveLevels[i] || 0;
+      if (lvl > prev) return lvl;
+      const decayed = Math.floor(prev * 0.2);
+      return lvl > decayed ? lvl : decayed;
+    });
+    prevWaveLevels = smoothed.slice();
+    return smoothed.map((l) => WAVE_CHARS[l]).join("");
+  } catch {
+    prevWaveLevels = Array(WAVE_LEN).fill(0);
+    return WAVE_CHARS[0].repeat(WAVE_LEN);
+  }
+}
+
+export function buildRecordingMessage() {
+  if (!useWave || recordingStartMs === null) return `${RECORDING_TOAST_BASE} · Ctrl+R to stop`;
+  const elapsed = formatElapsed(Date.now() - recordingStartMs);
+  const wave = getWaveString();
+  return `${RECORDING_TOAST_BASE}  ${wave}  ${elapsed} · Ctrl+R to stop`;
+}
+
 export function showRecordingToast() {
   clearRecordingToast();
+<<<<<<< HEAD
   if (!recordingToastFn) return;
   recordingToastFn({
     message: RECORDING_TOAST_MESSAGE,
     variant: "info",
     duration: RECORDING_TOAST_DURATION,
   });
+=======
+  recordingStartMs = Date.now();
+  prevWaveLevels = Array(WAVE_LEN).fill(0);
+  noiseFloorRms = null;
+  calibrationEndMs = Date.now() + 350;
+  const interval = useWave ? WAVE_INTERVAL : RECORDING_TOAST_INTERVAL;
+  const duration = useWave ? WAVE_DURATION : RECORDING_TOAST_DURATION;
+  if (recordingToastFn) {
+    recordingToastFn({
+      message: buildRecordingMessage(),
+      variant: "info",
+      duration,
+    });
+  }
+>>>>>>> 27eb481 (feat(stt): 16-col fixed-column waveform with noise gate)
   recordingToastTimer = setInterval(() => {
     if (recordingToastFn) {
       recordingToastFn({
-        message: RECORDING_TOAST_MESSAGE,
+        message: buildRecordingMessage(),
         variant: "info",
-        duration: RECORDING_TOAST_DURATION,
+        duration,
       });
     }
-  }, RECORDING_TOAST_INTERVAL);
+  }, interval);
 }
 
 export function clearRecordingToast() {
@@ -267,6 +427,9 @@ export function clearRecordingToast() {
     clearInterval(recordingToastTimer);
     recordingToastTimer = null;
   }
+  recordingStartMs = null;
+  noiseFloorRms = null;
+  calibrationEndMs = null;
 }
 
 function forceKillSox(logger) {

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -219,6 +219,57 @@ let soxStderr = "";
 let recording = false;
 let processing = false;
 
+// ---- Sticky recording toast (Option A: polling to simulate persistence) ----
+
+let recordingToastTimer = null;
+let recordingToastFn = null;
+const RECORDING_TOAST_MESSAGE = "🎙 Recording · Ctrl+R to stop";
+const RECORDING_TOAST_DURATION = 3000;
+const RECORDING_TOAST_INTERVAL = 2500;
+
+export function __setRecordingToastFn(fn) {
+  recordingToastFn = fn;
+}
+
+export function __clearRecordingToastState() {
+  if (recordingToastTimer) {
+    clearInterval(recordingToastTimer);
+    recordingToastTimer = null;
+  }
+  recordingToastFn = null;
+}
+
+export function isRecordingToastActive() {
+  return recordingToastTimer !== null;
+}
+
+export function showRecordingToast() {
+  clearRecordingToast();
+  if (recordingToastFn) {
+    recordingToastFn({
+      message: RECORDING_TOAST_MESSAGE,
+      variant: "info",
+      duration: RECORDING_TOAST_DURATION,
+    });
+  }
+  recordingToastTimer = setInterval(() => {
+    if (recordingToastFn) {
+      recordingToastFn({
+        message: RECORDING_TOAST_MESSAGE,
+        variant: "info",
+        duration: RECORDING_TOAST_DURATION,
+      });
+    }
+  }, RECORDING_TOAST_INTERVAL);
+}
+
+export function clearRecordingToast() {
+  if (recordingToastTimer) {
+    clearInterval(recordingToastTimer);
+    recordingToastTimer = null;
+  }
+}
+
 function forceKillSox(logger) {
   if (soxProc) {
     try {
@@ -271,6 +322,7 @@ function startRecording(kv, backend, toast, logger) {
     logger?.log("STT", `Recording failed: ${err.message}`, "error");
     if (recording) {
       recording = false;
+      clearRecordingToast();
       toast(`Recording failed: ${err.message}${audioFailureSuffix(backend)}`, "error");
     }
   });
@@ -282,13 +334,16 @@ function startRecording(kv, backend, toast, logger) {
       `sox exited code=${code} stderr=${soxStderr.trim()}`,
       code === 0 || code === null ? "debug" : "warn",
     );
-    if (recording && code !== 0 && code !== null && !processing) {
+    if (recording && !processing) {
       recording = false;
-      const errLine = soxStderr.trim().split("\n").pop();
-      toast(
-        `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
-        "error",
-      );
+      clearRecordingToast();
+      if (code !== 0 && code !== null) {
+        const errLine = soxStderr.trim().split("\n").pop();
+        toast(
+          `Recording error: ${errLine || `sox exited (code=${code})`}${audioFailureSuffix(backend)}`,
+          "error",
+        );
+      }
     }
   });
 
@@ -564,6 +619,7 @@ async function doTranscribePipeline(
   logger,
 ) {
   processing = true;
+  clearRecordingToast();
   try {
     logger?.log("STT", `Pipeline started submit=${submit}`, "debug");
     stopRecording(logger);
@@ -623,6 +679,9 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
     api.ui.toast({ message, variant, duration: 3000 });
   }
 
+  __setRecordingToastFn((input) => api.ui.toast(input));
+  api.lifecycle?.onDispose?.(() => clearRecordingToast());
+
   if (opts?.sttEndpoint) {
     sttApiEndpoint = opts.sttEndpoint;
     sttApiModel = opts.sttModel || "whisper-large-v3-turbo";
@@ -662,11 +721,12 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           return;
         }
         if (recording) {
+          clearRecordingToast();
           toast("Stopping, transcribing...");
           doTranscribePipeline(kv, complete, client, toast, systemPrompt, false, logger);
         } else {
           startRecording(kv, backend, toast, logger);
-          if (recording) toast("Recording... press again to transcribe");
+          if (recording) showRecordingToast();
         }
       },
     },
@@ -687,6 +747,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
           toast("No recording in progress", "warning");
           return;
         }
+        clearRecordingToast();
         toast("Stopping, transcribing...");
         doTranscribePipeline(kv, complete, client, toast, systemPrompt, true, logger);
       },
@@ -699,6 +760,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       onSelect() {
         if (recording) {
           recording = false;
+          clearRecordingToast();
           forceKillSox(logger);
           logger?.log("STT", "Recording cancelled", "debug");
           toast("Recording cancelled");


### PR DESCRIPTION
## Summary
Adds a live fixed-column waveform to the sticky recording toast. Replaces the scrolling tape with 16 bars that bounce in place, flat `▁` when silent, `█` when loud.

Depends on #17 (sticky toast) — this branch is stacked on `pr/sticky-toast`, diff below includes it; review #17 first or view `pr/waveform` vs `pr/sticky-toast`.

## ASCII — Visual work done

**Before (PR1, no wave):**
```
🎙 Recording · leader+[ to stop
```

**After (this PR, 16-col snapshot, 60ms poll):**
```
Silent (fan only, after 350ms calibration):
🎙 Recording  ▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁  00:01 · leader+[ to stop  (flat)

Soft speech (rms ~0.03):
🎙 Recording  ▁▂▃▂▅▃▂▃▁▂▃▂▁▃▁  00:03 · leader+[ to stop

Loud (rms ~0.20, close mic):
🎙 Recording  ▃▆▇█▆▅▇█▅▆▇█▃▆▇  00:05 · leader+[ to stop

Shout:
🎙 Recording  ████████████████  00:07 · leader+[ to stop
```

Fixed columns: each of 16 cols = RMS of sub-slice of last ~0.08s (`2560B` → `16×160B` chunks). No horizontal scroll, heights update in place every `60ms` (`WAVE_INTERVAL 60` / `WAVE_DURATION 220`).

**Noise gate:**
- First `350ms` after `Ctrl+R` calibrates `noiseFloorRms = min(...rawRms)` (fan hum).
- `effective = max(0, rms - noiseFloor*1.15)*1.6` → fan `~0.024` → `0` → flat, voice `~0.05` → `▅`.
- Instant attack, decay `prev*0.2` (was `0.55`) → loud `█` falls to `▂` in 1 tick, then `▁` — snappy, explicit.

## Changes
- `lib/stt.js:230-410` — `WAVE_LEN 16`, `WAVE_INTERVAL 60`, `WAVE_DURATION 220`, `noiseFloorRms`/`calibrationEndMs`, `rmsToLevel` thresholds `0.008-0.24`, `getWaveString()` snapshot + gate + gain, `prevWaveLevels` decay.

## Testing
- `npm run check`/`npm test` pass
- Manual `leader+[` → silent flat `▁×16`, speak → bars jump `▆▇█`, fan alone stays flat after calibration; timer `00:00` ticks.

