### PR TITLE
feat(tui): palette-first keybinds with leader+[

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,17 +15,20 @@
 //
 // Runtime state (model, mic, voice, tts mode) persisted via api.kv.
 //
-// Commands:
-//   /stt-record (ctrl+r)  - start/stop recording + transcribe
-//   /stt-submit (leader+r)- stop recording + transcribe + submit
-//   /stt-stop             - cancel recording
-//   /stt-model            - select whisper model
-//   /stt-language         - select transcription language
-//   /stt-mic              - select microphone
-//   /tts-speak (leader+s)- read last response aloud
-//   /tts-mode (leader+v) - toggle auto TTS on/off
-//   /tts-stop (escape)   - stop playback
+// Commands (palette + slash; default shortcuts use rare leader combos to avoid collisions):
+//   /stt-record          - start/stop recording + transcribe  (default: <leader>[ = ctrl+x, [)
+//   /stt-submit          - stop recording + transcribe + submit (palette-only)
+//   /stt-stop            - cancel recording (palette-only)
+//   /stt-model           - select whisper model
+//   /stt-language        - select transcription language
+//   /stt-mic             - select microphone
+//   /tts-speak           - read last response aloud        (default: <leader>] = ctrl+x, ])
+//   /tts-mode            - toggle auto TTS on/off (palette-only)
+//   /tts-stop            - stop playback                   (default: <leader>; , also palette)
 //   /tts-voice           - select TTS voice
+//   All also palette-accessible via Ctrl+P or /slash. Override via plugin options `keybinds`:
+//   { "keybinds": { "stt.record": "<leader>R", "tts.speak-last": "none" } }
+//   Weird keys [ ] ; were chosen because opencode doesn't use them and uppercase/shift was ignored.
 
 import fs from "node:fs";
 import os from "node:os";
@@ -66,7 +69,7 @@ export default {
     };
 
     const sttCommands = registerSTT(api, kv, complete, prompts, options, logger);
-    const ttsCommands = registerTTS(api, kv, complete, prompts, logger);
+    const ttsCommands = registerTTS(api, kv, complete, prompts, options, logger);
 
     api.command.register(() => [...sttCommands, ...ttsCommands]);
   },

--- a/index.js
+++ b/index.js
@@ -27,8 +27,8 @@
 //   /tts-stop            - stop playback                   (default: <leader>; , also palette)
 //   /tts-voice           - select TTS voice
 //   All also palette-accessible via Ctrl+P or /slash. Override via plugin options `keybinds`:
-//   { "keybinds": { "stt.record": "<leader>R", "tts.speak-last": "none" } }
-//   Weird keys [ ] ; were chosen because opencode doesn't use them and uppercase/shift was ignored.
+//   { "keybinds": { "stt.record": "ctrl+r", "tts.speak-last": "none" } }
+//   Weird keys [ ] ; were chosen because opencode doesn't use them and shift variants were ignored in terminals.
 
 import fs from "node:fs";
 import os from "node:os";

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -647,6 +647,18 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
   }
   logger?.log("STT", `STT temp dir=${tmpDir}`, "debug");
 
+  const DEFAULT_KEYBINDS = {
+    "stt.record": "<leader>[",
+  };
+  function kb(value) {
+    if (opts?.keybinds && value in opts.keybinds) {
+      const v = opts.keybinds[value];
+      if (!v || v === "none") return undefined;
+      return v;
+    }
+    return DEFAULT_KEYBINDS[value];
+  }
+
   return [
     {
       title: sttApiEndpoint ? "STT: record/transcribe (API)" : "STT: record/transcribe",
@@ -654,7 +666,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       description: sttApiEndpoint
         ? "Toggle recording; press again to stop and transcribe via API"
         : "Toggle recording; press again to stop and transcribe",
-      keybind: "ctrl+r",
+      ...(kb("stt.record") ? { keybind: kb("stt.record") } : {}),
       slash: { name: "stt-record" },
       onSelect() {
         if (processing) {
@@ -676,7 +688,7 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
       description: sttApiEndpoint
         ? "Stop recording, transcribe via API, and submit prompt"
         : "Stop recording, transcribe, and submit prompt",
-      keybind: "<leader>r",
+      ...(kb("stt.submit") ? { keybind: kb("stt.submit") } : {}),
       slash: { name: "stt-submit" },
       onSelect() {
         if (processing) {

--- a/lib/stt.js
+++ b/lib/stt.js
@@ -651,12 +651,12 @@ export function registerSTT(api, kv, complete, prompts, opts, logger) {
     "stt.record": "<leader>[",
   };
   function kb(value) {
-    if (opts?.keybinds && value in opts.keybinds) {
-      const v = opts.keybinds[value];
-      if (!v || v === "none") return undefined;
-      return v;
-    }
-    return DEFAULT_KEYBINDS[value];
+    const kb = opts?.keybinds;
+    if (!kb || typeof kb !== "object" || Array.isArray(kb)) return DEFAULT_KEYBINDS[value];
+    if (!Object.prototype.hasOwnProperty.call(kb, value)) return DEFAULT_KEYBINDS[value];
+    const v = kb[value];
+    if (!v || v === "none") return undefined;
+    return v;
   }
 
   return [

--- a/lib/tts.js
+++ b/lib/tts.js
@@ -343,12 +343,12 @@ export function registerTTS(api, kv, complete, prompts, opts, logger) {
     "tts.stop": "<leader>;",
   };
   function kb(value) {
-    if (opts?.keybinds && value in opts.keybinds) {
-      const v = opts.keybinds[value];
-      if (!v || v === "none") return undefined;
-      return v;
-    }
-    return DEFAULT_KEYBINDS[value];
+    const kb = opts?.keybinds;
+    if (!kb || typeof kb !== "object" || Array.isArray(kb)) return DEFAULT_KEYBINDS[value];
+    if (!Object.prototype.hasOwnProperty.call(kb, value)) return DEFAULT_KEYBINDS[value];
+    const v = kb[value];
+    if (!v || v === "none") return undefined;
+    return v;
   }
 
   // ---- Commands ----

--- a/lib/tts.js
+++ b/lib/tts.js
@@ -104,7 +104,7 @@ async function getTurnAssistantText(client, api) {
 
 // ---- Public API for TUI plugin ----
 
-export function registerTTS(api, kv, complete, prompts, logger) {
+export function registerTTS(api, kv, complete, prompts, opts, logger) {
   const client = api.client;
   const systemAuto = prompts?.ttsAuto || SYSTEM_AUTO;
   const systemManual = prompts?.ttsManual || SYSTEM_MANUAL;
@@ -338,6 +338,19 @@ export function registerTTS(api, kv, complete, prompts, logger) {
     await speak(llmResult.text);
   }
 
+  const DEFAULT_KEYBINDS = {
+    "tts.speak-last": "<leader>]",
+    "tts.stop": "<leader>;",
+  };
+  function kb(value) {
+    if (opts?.keybinds && value in opts.keybinds) {
+      const v = opts.keybinds[value];
+      if (!v || v === "none") return undefined;
+      return v;
+    }
+    return DEFAULT_KEYBINDS[value];
+  }
+
   // ---- Commands ----
 
   return [
@@ -345,7 +358,7 @@ export function registerTTS(api, kv, complete, prompts, logger) {
       title: "TTS: speak last response",
       value: "tts.speak-last",
       description: "Read the last assistant response aloud (detailed)",
-      keybind: "<leader>s",
+      ...(kb("tts.speak-last") ? { keybind: kb("tts.speak-last") } : {}),
       slash: { name: "tts-speak" },
       onSelect() {
         speakLastResponse();
@@ -355,7 +368,7 @@ export function registerTTS(api, kv, complete, prompts, logger) {
       title: "TTS: toggle",
       value: "tts.mode",
       description: "Toggle auto text-to-speech on/off",
-      keybind: "<leader>v",
+      ...(kb("tts.mode") ? { keybind: kb("tts.mode") } : {}),
       slash: { name: "tts-mode" },
       onSelect() {
         const current = kv.get("tts.mode", "off");
@@ -371,7 +384,7 @@ export function registerTTS(api, kv, complete, prompts, logger) {
       title: "TTS: stop playback",
       value: "tts.stop",
       description: "Stop current TTS playback",
-      keybind: "escape",
+      ...(kb("tts.stop") ? { keybind: kb("tts.stop") } : {}),
       slash: { name: "tts-stop" },
       onSelect() {
         if (stopSpeech()) toast("TTS stopped");


### PR DESCRIPTION
## Summary
Makes voice commands palette-first and gives them weird-but-safe `leader+[` shortcuts that don't collide with `opencode` defaults (`ctrl+r` = `session_rename`). Previously hardcoded `ctrl+r` / `<leader>r/s/v` / `escape` overwrote favorites.

## ASCII — Before / After

**Before (hardcoded, colliding):**
```
tui.json keybinds: session_rename:none  ← needed to free ctrl+r

Plugin:
  stt.record  → ctrl+r        (collides session_rename)
  stt.submit  → <leader>r     (ctrl+x r)
  tts.speak   → <leader>s     (ctrl+x s)
  tts.stop    → escape
  ┌─► user favorite key overwritten
```

**After (this PR, palette + weird leader):**
```
tui.json keybinds: (no override needed, plugin no longer steals ctrl+r)

Plugin (palette always):
  Ctrl+P → STT: record/transcribe  (/stt-record)
  Ctrl+P → TTS: speak last response (/tts-speak)
  etc. — all slash + palette

Optional shortcuts (weird, free keys):
  stt.record     → <leader>[   (ctrl+x → [ )
  tts.speak-last → <leader>]   (ctrl+x → ] )
  tts.stop       → <leader>;   (ctrl+x → ; )
  ┌─► [ ] ; never used by opencode, so no collision
  ┌─► ctrl+shift often collapses to ctrl in terminals, so leader+shift (uppercase) also ignored → weird keys chosen

Toast helper now dynamic:
  Before: 🎙 Recording · Ctrl+R to stop  (wrong after remap)
  After:  🎙 Recording  ▁▁▁▁  00:02 · leader+[ to stop  (reads opts.keybinds["stt.record"] via __setRecordKeybind)

Override / disable:
  tui.json plugin options:
    "keybinds": { "stt.record": "ctrl+r" }          // remap
    "keybinds": { "stt.record": "none" }            // palette-only
```

**Why `leader+[` not `ctrl+shift+r` / `<leader>R`?**
- `@opentui/keymap` does distinguish `shift` (`ctrl+shift+r` parsed as `ctrl:true, shift:true`), but most terminals send `Ctrl+Shift+r` as `Ctrl+r` (shift lost). Tested `ctrl+shift+r` → opencode didn't fire, `<leader>R` (shift+R) also ignored. Weird `[ ] ;` are unshifted symbols, so they survive.

## Changes
- `lib/stt.js:924-947` — `DEFAULT_KEYBINDS = {"stt.record":"<leader>["}`, `kb()` helper checks `opts.keybinds[v]` (`"none"` disables), `__setRecordKeybind` for dynamic toast.
- `lib/tts.js:341-365` — same for `tts.speak-last`/`tts.stop` → `<leader>]`/`<leader>;`.
- `index.js:58-73` — pass `options` to `registerTTS`, update header comments to palette + weird defaults.
- `lib/stt.js:391` — `buildRecordingMessage()` now uses `currentRecordKeybind` (`leader+[`).

## Testing
- `npm run check`/`npm test` pass
- `registerSTT(mock, {}, ...)` → `stt.record` keybind `<leader>[` ; with `keybinds:{ "stt.record":"none" }` → no keybind; with `"ctrl+r"` → `ctrl+r`.
- Manual `leader+[` in TUI toggles recording, palette `/stt-record` still works, `session_rename` now free.

## Stack
Base `main`, independent from sticky/wave/llm (touches different hunks than wave). Mergeable in any order, but rebase if `lib/stt.js` conflicts with wave.

